### PR TITLE
fixed problem from dropping RECORD_PROJECTION cursor style

### DIFF
--- a/core/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
+++ b/core/src/main/java/org/apache/calcite/avatica/remote/LocalService.java
@@ -97,20 +97,24 @@ public class LocalService implements Service {
 
     if (resultSet.firstFrame != null) {
       list = list(resultSet.firstFrame.rows);
-      switch (cursorFactory.style) {
-      case ARRAY:
+      if (list.isEmpty()) {
         cursorFactory = Meta.CursorFactory.LIST;
-        break;
-      case MAP:
-      case LIST:
-        break;
-      case RECORD:
-        cursorFactory = Meta.CursorFactory.LIST;
-        break;
-      default:
-        cursorFactory = Meta.CursorFactory.map(cursorFactory.fieldNames);
+      } else {
+        switch (cursorFactory.style) {
+        case ARRAY:
+          cursorFactory = Meta.CursorFactory.LIST;
+          break;
+        case MAP:
+        case LIST:
+          break;
+        case RECORD:
+          cursorFactory = Meta.CursorFactory.map(cursorFactory.fieldNames);
+          break;
+        default:
+          throw new IllegalStateException("Unknown cursor factory style: "
+              + cursorFactory.style);
+        }
       }
-
       final boolean done = resultSet.firstFrame.done;
 
       frame = new Meta.Frame(0, done, list);


### PR DESCRIPTION
Hello @zabetak, I have fixed the issue, RECORD_PROJECTION was implicitly used in `LocalService` class by means of the default case of a switch over the cursor factory style.

Tested locally, all tests are now passing, both on Avatica and Calcite.

Please note that there is a typo in your commit message: `Close apache/caclite-avatica#138` instead of `Close apache/calcite-avatica#138`.

I think you can just squash the commit if you agree on the change, the commit message (typo excluded) is already OK.